### PR TITLE
Inline commands

### DIFF
--- a/src/main/java/com/github/quiltservertools/blockbot/Config.java
+++ b/src/main/java/com/github/quiltservertools/blockbot/Config.java
@@ -3,6 +3,7 @@ package com.github.quiltservertools.blockbot;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import net.dv8tion.jda.api.entities.Role;
 import net.fabricmc.loader.api.FabricLoader;
 
 import java.io.IOException;
@@ -16,30 +17,33 @@ public class Config {
     private String channel;
     private String webhook;
     private String adminRoleId;
+    private boolean inlineCommands;
 
     public Config() {
         JsonObject json;
         try {
             json = new JsonParser().parse(new String(Files.readAllBytes(path))).getAsJsonObject();
-            identifier = json.get("token").getAsString();
-            channel = json.get("channel_id").getAsString();
-            webhook = json.get("webhook").getAsString();
-            adminRoleId = json.get("op_role_id").getAsString();
+            loadFromJson(json);
         } catch (IOException e) {
             // Create default
             try {
                 Files.copy(Objects.requireNonNull(Config.class.getResourceAsStream("/data/blockbot/files/default_config.json")), path);
                 json = new JsonParser().parse(new String(Files.readAllBytes(path))).getAsJsonObject();
-                identifier = json.get("token").getAsString();
-                channel = json.get("channel_id").getAsString();
-                webhook = json.get("webhook").getAsString();
-                adminRoleId = json.get("op_role_id").getAsString();
+                loadFromJson(json);
             } catch (IOException ioException) {
                 ioException.printStackTrace();
                 BlockBot.LOG.error("Unable to create default config");
                 BlockBot.LOG.error("Please fill out the config file for BlockBot");
             }
         }
+    }
+
+    private void loadFromJson(JsonObject json) {
+        identifier = json.get("token").getAsString();
+        channel = json.get("channel_id").getAsString();
+        webhook = json.get("webhook").getAsString();
+        adminRoleId = json.get("op_role_id").getAsString();
+        inlineCommands = json.get("inline_commands").getAsBoolean();
     }
 
     public String getIdentifier() {
@@ -52,6 +56,14 @@ public class Config {
 
     public String getAdminRoleId() {
         return adminRoleId;
+    }
+
+    public boolean adminRole(Role role) {
+        return role.getId().equals(this.adminRoleId);
+    }
+
+    public boolean enableInlineCommands() {
+        return inlineCommands;
     }
 
     public void shutdown() {

--- a/src/main/java/com/github/quiltservertools/blockbot/Discord.java
+++ b/src/main/java/com/github/quiltservertools/blockbot/Discord.java
@@ -29,7 +29,7 @@ public class Discord {
 
     public Discord(Config config, MinecraftServer server) throws LoginException {
         jda = JDABuilder.createDefault(config.getIdentifier()).build();
-        jda.addEventListener(new Listeners(config.getChannel(), server));
+        jda.addEventListener(new Listeners(config, server));
         System.out.println(config.getChannel());
         BlockBot.LOG.info("Setup discord bot with token provided");
 

--- a/src/main/java/com/github/quiltservertools/blockbot/Listeners.java
+++ b/src/main/java/com/github/quiltservertools/blockbot/Listeners.java
@@ -1,5 +1,8 @@
 package com.github.quiltservertools.blockbot;
 
+import com.github.quiltservertools.blockbot.command.discord.DiscordCommandOutput;
+import com.github.quiltservertools.blockbot.command.discord.DiscordCommandOutputHelper;
+import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.minecraft.network.MessageType;
@@ -24,8 +27,23 @@ public class Listeners extends ListenerAdapter {
 
     @Override
     public void onMessageReceived(@NotNull MessageReceivedEvent event) {
-        if (event.getChannel().getId().equals(channel) && !event.getMessage().isWebhookMessage()) {
-            sendMessageToGame(server, event);
+        Message message = event.getMessage();
+        if (event.getChannel().getId().equals(channel) && !message.getAuthor().isBot()) {
+            String content = message.getContentRaw();
+            if (content.startsWith("//")) {
+                String minecraftCommand = content.substring(2);
+                this.server.execute(() -> {
+                    DiscordCommandOutput output = DiscordCommandOutputHelper.createOutput(event.getTextChannel());
+                    this.server.getCommandManager().execute(DiscordCommandOutputHelper.buildCommandSource(
+                            this.server,
+                            Objects.requireNonNull(event.getMember(), "event.getMember()"),
+                            output
+                    ), minecraftCommand);
+                    output.sendBufferedContent();
+                });
+            } else {
+                sendMessageToGame(server, event);
+            }
         }
     }
 

--- a/src/main/java/com/github/quiltservertools/blockbot/command/discord/DiscordCommandOutput.java
+++ b/src/main/java/com/github/quiltservertools/blockbot/command/discord/DiscordCommandOutput.java
@@ -1,0 +1,58 @@
+package com.github.quiltservertools.blockbot.command.discord;
+
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.minecraft.server.command.CommandOutput;
+import net.minecraft.text.Text;
+
+import java.util.UUID;
+
+public class DiscordCommandOutput implements CommandOutput {
+    private final StringBuffer buffer = new StringBuffer();
+    private boolean shouldBuffer = true;
+    private final TextChannel channel;
+
+    public DiscordCommandOutput(TextChannel channel) {
+        this.channel = channel;
+    }
+
+    @Override
+    public void sendSystemMessage(Text message, UUID senderUuid) {
+        String content = message.getString();
+
+        if (shouldBuffer) {
+            if (buffer.length() + content.length() > 2000) { // discord character limit
+                channel.sendMessage(buffer).queue();
+                buffer.delete(0, buffer.length());
+            }
+
+            if (buffer.length() > 0) {
+                buffer.append('\n');
+            }
+            buffer.append(content);
+        } else {
+            this.channel.sendMessage(content).queue();
+        }
+    }
+
+    @Override
+    public boolean shouldReceiveFeedback() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldTrackOutput() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldBroadcastConsoleToOps() {
+        return true;
+    }
+
+    public void sendBufferedContent() {
+        if (this.buffer.length() > 0) {
+            this.channel.sendMessage(this.buffer).queue();
+        }
+        this.shouldBuffer = false;
+    }
+}

--- a/src/main/java/com/github/quiltservertools/blockbot/command/discord/DiscordCommandOutputHelper.java
+++ b/src/main/java/com/github/quiltservertools/blockbot/command/discord/DiscordCommandOutputHelper.java
@@ -1,0 +1,25 @@
+package com.github.quiltservertools.blockbot.command.discord;
+
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.command.CommandOutput;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.LiteralText;
+import net.minecraft.util.math.Vec2f;
+import net.minecraft.util.math.Vec3d;
+
+public class DiscordCommandOutputHelper {
+
+    public static ServerCommandSource buildCommandSource(MinecraftServer server, Member member, CommandOutput output) {
+        boolean allowedOp = member.isOwner() || member.hasPermission(Permission.ADMINISTRATOR);
+        String username = '@' + member.getEffectiveName() + '#' + member.getUser().getDiscriminator();
+        return new ServerCommandSource(output, Vec3d.ZERO, Vec2f.ZERO, server.getOverworld(), allowedOp ? 4 : 0,
+                username, new LiteralText(username), server, null);
+    }
+
+    public static DiscordCommandOutput createOutput(TextChannel channel) {
+        return new DiscordCommandOutput(channel);
+    }
+}

--- a/src/main/java/com/github/quiltservertools/blockbot/command/discord/DiscordCommandOutputHelper.java
+++ b/src/main/java/com/github/quiltservertools/blockbot/command/discord/DiscordCommandOutputHelper.java
@@ -12,8 +12,8 @@ import net.minecraft.util.math.Vec3d;
 
 public class DiscordCommandOutputHelper {
 
-    public static ServerCommandSource buildCommandSource(MinecraftServer server, Member member, CommandOutput output) {
-        boolean allowedOp = member.isOwner() || member.hasPermission(Permission.ADMINISTRATOR);
+    public static ServerCommandSource buildCommandSource(MinecraftServer server, Member member, CommandOutput output, boolean isAdmin) {
+        boolean allowedOp = member.isOwner() || member.hasPermission(Permission.ADMINISTRATOR) || isAdmin;
         String username = '@' + member.getEffectiveName() + '#' + member.getUser().getDiscriminator();
         return new ServerCommandSource(output, Vec3d.ZERO, Vec2f.ZERO, server.getOverworld(), allowedOp ? 4 : 0,
                 username, new LiteralText(username), server, null);

--- a/src/main/resources/data/blockbot/files/default_config.json
+++ b/src/main/resources/data/blockbot/files/default_config.json
@@ -2,5 +2,6 @@
   "token": "",
   "channel_id": "",
   "webhook": "",
-  "op_role_id": ""
+  "op_role_id": "",
+  "inline_commands": true
 }


### PR DESCRIPTION
Adds support for inline Minecraft commands in the bridge channel using the prefix `//`.

### Buffering
Command output is buffered until the initial command action has been completed, then it is sent one message per line (some commands may trigger asynchronous actions that have output, idk ¯\\_(ツ)_/¯). This buffering helps to prevent against commands such as `//help` taking a long time to run as each line is sent as a separate message and discord rate-limiting slows  this down.

### Config
This adds a new config option, `inline_commands`, that toggles this functionality on/off.
It also makes use of the `admin_role_id` to grant operator level 4 users with the role.

### Permissions
Inline commands are run with a computed permission level of either 0 or 4. Permission level 4 is only granted when the user has `ADMINISTRATOR` permissions on discord, or they have the role specified in the `admin_role_id` config option. All other users receive OP level 0, which is equivalent to the base permissions of a default player.