### PR TITLE
Make the @ gray and italicized

### DIFF
--- a/src/main/java/com/github/quiltservertools/blockbot/Listeners.java
+++ b/src/main/java/com/github/quiltservertools/blockbot/Listeners.java
@@ -61,7 +61,7 @@ public class Listeners extends ListenerAdapter {
         String msg = event.getMessage().getContentDisplay();
         int colour = Objects.requireNonNull(event.getMember()).getColorRaw();
         Text message = new LiteralText(msg);
-        MutableText sender = new LiteralText("<@").append(new LiteralText(event.getMember().getEffectiveName()).styled(style -> style.withColor(TextColor.fromRgb(colour)))).append(new LiteralText("> "));
+        MutableText sender = new LiteralText("<§7§o@§r").append(new LiteralText(event.getMember().getEffectiveName()).styled(style -> style.withColor(TextColor.fromRgb(colour)))).append(new LiteralText("> "));
         if (!event.getMessage().getAttachments().isEmpty()) {
             event.getMessage().getAttachments().forEach(attachment -> server.getPlayerManager().broadcastChatMessage(sender.append(new LiteralText(attachment.getUrl()).styled(s -> s.withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, attachment.getUrl())))), MessageType.SYSTEM, Util.NIL_UUID));
             if (!msg.equals("")) server.getPlayerManager().broadcastChatMessage(sender.append(message), MessageType.SYSTEM, Util.NIL_UUID);


### PR DESCRIPTION
After playtesting the mod with a discord server where I had a red role color, I've noticed the white @ is too prominent and stood out too much in contrast with my red name, so I changed it to be gray and italicized, so even if a role color is gray, you can still see the italics and differentiate the @ with the discord name.

The main reason I'm proposing this change is because I believe it is best if the username is prominent and not the @ symbol.