### PR TITLE
add: Discord role sync

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,6 +97,9 @@ dependencies {
     modImplementation(libs.placeholder.api)
     include(libs.placeholder.api)
 
+    modImplementation(libs.permission.api)
+    include(libs.permission.api)
+
     shadow(libs.mcDiscordReserializer)
     shadow(libs.adventure.gson)
 

--- a/src/main/kotlin/io/github/quiltservertools/blockbotdiscord/config/LinkingSpec.kt
+++ b/src/main/kotlin/io/github/quiltservertools/blockbotdiscord/config/LinkingSpec.kt
@@ -18,6 +18,7 @@ object LinkingSpec : ConfigSpec() {
     val nicknameSync by required<Boolean>()
     val unlinkedDisconnectMessage by required<List<String>>()
     val requiredRoles by required<List<ULong>>()
+    val syncedRoles by required<Map<String, ULong>>()
     val requiredRoleDisconnectMessage by required<String>()
     val requireInServer by required<Boolean>()
     val notInServerMessage by required<String>()

--- a/src/main/kotlin/io/github/quiltservertools/blockbotdiscord/extensions/linking/LinkCommand.kt
+++ b/src/main/kotlin/io/github/quiltservertools/blockbotdiscord/extensions/linking/LinkCommand.kt
@@ -133,7 +133,7 @@ class LinkCommand(private val dispatcher: Dispatcher) {
                         )
                     ), false
                 )
-                player.syncLinkedName(BlockBotDiscord.bot.getKoin().get())
+                player.syncDiscord()
             }
         }
         return 1

--- a/src/main/resources/blockbot-discord.toml
+++ b/src/main/resources/blockbot-discord.toml
@@ -113,6 +113,8 @@ requireLinking = false
 nicknameSync = false
 # Comma seperated list of role ID's allowed to join the server. Leave blank to allow any linked account to join. Also restricts /link command in discord
 requiredRoles = []
+# A map of role ID's and minecraft group ID's. Syncs roles if the player has blockbot.sync.<group_id> permission
+syncedRoles = {}
 # Require linked players to be in the main discord
 requireInServer = false
 # Message to show when linked players try to join without the required role


### PR DESCRIPTION
- Adds config option for giving discord members roles if they have `blockbot.sync.<group_id>` permission in-game.
- Adds `blockbot.sync.name` permission (enabled by default) to disable name syncing for specific players

*This also removes the check if the bot is higher than the edited member, because it doesn't seem to be an appropriate metric for measuring if the bot is allowed (The bot also needs permission and, from testing, can't edit the server owner). The check has been replaced with a catch for `RestRequestException` (I don't know if the API provides any proper way to check if the bot is allowed to perform an action)*