### PR TITLE
Update to 1.20.4

### DIFF
--- a/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/BlockBotApi.java
+++ b/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/BlockBotApi.java
@@ -1,15 +1,12 @@
 package io.github.quiltservertools.blockbotapi;
 
-import io.github.quiltservertools.blockbotapi.event.ChatMessageEvent;
-import io.github.quiltservertools.blockbotapi.event.PlayerAdvancementGrantEvent;
-import io.github.quiltservertools.blockbotapi.event.PlayerDeathEvent;
+import io.github.quiltservertools.blockbotapi.event.*;
 import io.github.quiltservertools.blockbotapi.sender.MessageSender;
 import io.github.quiltservertools.blockbotapi.sender.PlayerMessageSender;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.message.v1.ServerMessageEvents;
-import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -38,8 +35,8 @@ public class BlockBotApi implements ModInitializer {
         BlockBotApi.bots.add(bot);
 
         ChatMessageEvent.EVENT.register(bot::onChatMessage);
-        ServerPlayConnectionEvents.JOIN.register(bot::onPlayerConnect);
-        ServerPlayConnectionEvents.DISCONNECT.register(bot::onPlayerDisconnect);
+        PlayerJoinMessageEvent.EVENT.register(bot::onPlayerJoinMessage);
+        PlayerLeaveMessageEvent.EVENT.register(bot::onPlayerLeaveMessage);
         PlayerDeathEvent.EVENT.register(bot::onPlayerDeath);
         PlayerAdvancementGrantEvent.EVENT.register(bot::onAdvancementGrant);
         ServerLifecycleEvents.SERVER_STARTED.register(bot::onServerStart);

--- a/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/Bot.java
+++ b/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/Bot.java
@@ -10,8 +10,8 @@ import net.minecraft.text.Text;
 
 public interface Bot {
     void onChatMessage(MessageSender sender, Text message);
-    void onPlayerConnect(ServerPlayNetworkHandler handler, PacketSender sender, MinecraftServer server);
-    void onPlayerDisconnect(ServerPlayNetworkHandler handler, MinecraftServer server);
+    void onPlayerJoinMessage(ServerPlayerEntity player);
+    void onPlayerLeaveMessage(ServerPlayerEntity player);
     void onPlayerDeath(ServerPlayerEntity player, Text message);
     void onAdvancementGrant(ServerPlayerEntity player, Advancement advancement);
     void onServerStart(MinecraftServer server);

--- a/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/event/PlayerJoinMessageEvent.java
+++ b/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/event/PlayerJoinMessageEvent.java
@@ -1,0 +1,15 @@
+package io.github.quiltservertools.blockbotapi.event;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+public interface PlayerJoinMessageEvent {
+    Event<PlayerJoinMessageEvent> EVENT = EventFactory.createArrayBacked(PlayerJoinMessageEvent.class, (listeners) -> (player) -> {
+        for (PlayerJoinMessageEvent listener : listeners) {
+            listener.onPlayerJoinMessage(player);
+        }
+    });
+
+    void onPlayerJoinMessage(ServerPlayerEntity player);
+}

--- a/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/event/PlayerLeaveMessageEvent.java
+++ b/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/event/PlayerLeaveMessageEvent.java
@@ -1,0 +1,15 @@
+package io.github.quiltservertools.blockbotapi.event;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+public interface PlayerLeaveMessageEvent {
+    Event<PlayerLeaveMessageEvent> EVENT = EventFactory.createArrayBacked(PlayerLeaveMessageEvent.class, (listeners) -> (player) -> {
+        for (PlayerLeaveMessageEvent listener : listeners) {
+            listener.onPlayerLeaveMessage(player);
+        }
+    });
+
+    void onPlayerLeaveMessage(ServerPlayerEntity player);
+}

--- a/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/mixin/MeCommandMixin.java
+++ b/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/mixin/MeCommandMixin.java
@@ -3,13 +3,9 @@ package io.github.quiltservertools.blockbotapi.mixin;
 import com.mojang.brigadier.context.CommandContext;
 import io.github.quiltservertools.blockbotapi.event.ChatMessageEvent;
 import io.github.quiltservertools.blockbotapi.sender.MessageSender;
-import io.github.quiltservertools.blockbotapi.sender.PlayerMessageSender;
 import net.minecraft.network.message.SignedMessage;
-import net.minecraft.server.PlayerManager;
 import net.minecraft.server.command.MeCommand;
 import net.minecraft.server.command.ServerCommandSource;
-import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -22,21 +18,7 @@ public abstract class MeCommandMixin {
         at = @At(value = "INVOKE", target = "Lnet/minecraft/server/PlayerManager;broadcast(Lnet/minecraft/network/message/SignedMessage;Lnet/minecraft/server/command/ServerCommandSource;Lnet/minecraft/network/message/MessageType$Parameters;)V")
     )
     private static void relayPlayerMeToDiscord(CommandContext<ServerCommandSource> ctx, SignedMessage message, CallbackInfo ci) {
-        var entity = ctx.getSource().getEntity();
-        MessageSender sender;
-        if (entity instanceof ServerPlayerEntity player) {
-            sender = new PlayerMessageSender(
-                player,
-                MessageSender.MessageType.EMOTE
-            );
-        } else {
-            sender = new MessageSender(
-                Text.literal(ctx.getSource().getName()),
-                ctx.getSource().getDisplayName(),
-                MessageSender.MessageType.EMOTE
-            );
-        }
-
+        MessageSender sender = MessageSender.of(ctx.getSource(), MessageSender.MessageType.EMOTE);
         ChatMessageEvent.EVENT.invoker().message(
             sender,
             message.getContent()

--- a/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/mixin/PlayerManagerMixin.java
+++ b/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/mixin/PlayerManagerMixin.java
@@ -1,0 +1,25 @@
+package io.github.quiltservertools.blockbotapi.mixin;
+
+import io.github.quiltservertools.blockbotapi.event.PlayerJoinMessageEvent;
+import net.minecraft.network.ClientConnection;
+import net.minecraft.server.PlayerManager;
+import net.minecraft.server.network.ConnectedClientData;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(PlayerManager.class)
+public abstract class PlayerManagerMixin {
+    @Inject(
+        method = "onPlayerConnect",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/server/PlayerManager;broadcast(Lnet/minecraft/text/Text;Z)V"
+        )
+    )
+    private void relayJoinMessageToDiscord(ClientConnection connection, ServerPlayerEntity player, ConnectedClientData clientData, CallbackInfo ci) {
+        PlayerJoinMessageEvent.EVENT.invoker().onPlayerJoinMessage(player);
+    }
+}

--- a/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/mixin/RandomCommandMixin.java
+++ b/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/mixin/RandomCommandMixin.java
@@ -1,0 +1,34 @@
+package io.github.quiltservertools.blockbotapi.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import io.github.quiltservertools.blockbotapi.event.ChatMessageEvent;
+import io.github.quiltservertools.blockbotapi.sender.MessageSender;
+import net.minecraft.server.PlayerManager;
+import net.minecraft.server.command.RandomCommand;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(RandomCommand.class)
+public abstract class RandomCommandMixin {
+
+    @WrapOperation(
+        method = "execute",
+        at = @At(
+            value = "INVOKE", target = "Lnet/minecraft/server/PlayerManager;broadcast(Lnet/minecraft/text/Text;Z)V"
+        )
+    )
+    private static void relayRandomRollToDiscord(PlayerManager instance, Text message, boolean overlay, Operation<Void> original, ServerCommandSource source) {
+        original.call(instance, message, overlay);
+        MessageSender sender = MessageSender.of(source, MessageSender.MessageType.ANNOUNCEMENT);
+        ChatMessageEvent.EVENT.invoker().message(
+            sender,
+            // Change translation to literal
+            Text.literal(message.getString())
+        );
+    }
+
+}

--- a/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/mixin/SayCommandMixin.java
+++ b/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/mixin/SayCommandMixin.java
@@ -3,13 +3,9 @@ package io.github.quiltservertools.blockbotapi.mixin;
 import com.mojang.brigadier.context.CommandContext;
 import io.github.quiltservertools.blockbotapi.event.ChatMessageEvent;
 import io.github.quiltservertools.blockbotapi.sender.MessageSender;
-import io.github.quiltservertools.blockbotapi.sender.PlayerMessageSender;
 import net.minecraft.network.message.SignedMessage;
-import net.minecraft.server.PlayerManager;
 import net.minecraft.server.command.SayCommand;
 import net.minecraft.server.command.ServerCommandSource;
-import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -22,21 +18,7 @@ public abstract class SayCommandMixin {
         at = @At(value = "INVOKE", target = "Lnet/minecraft/server/PlayerManager;broadcast(Lnet/minecraft/network/message/SignedMessage;Lnet/minecraft/server/command/ServerCommandSource;Lnet/minecraft/network/message/MessageType$Parameters;)V")
     )
     private static void relayPlayerSayToDiscord(CommandContext<ServerCommandSource> ctx, SignedMessage message, CallbackInfo ci) {
-        var entity = ctx.getSource().getEntity();
-        MessageSender sender;
-        if (entity instanceof ServerPlayerEntity player) {
-            sender = new PlayerMessageSender(
-                player,
-                MessageSender.MessageType.ANNOUNCEMENT
-            );
-        } else {
-            sender = new MessageSender(
-                Text.literal(ctx.getSource().getName()),
-                ctx.getSource().getDisplayName(),
-                MessageSender.MessageType.ANNOUNCEMENT
-            );
-        }
-
+        MessageSender sender = MessageSender.of(ctx.getSource(), MessageSender.MessageType.ANNOUNCEMENT);
         ChatMessageEvent.EVENT.invoker().message(
             sender,
             message.getContent()

--- a/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/mixin/ServerPlayNetworkHandlerMixin.java
+++ b/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/mixin/ServerPlayNetworkHandlerMixin.java
@@ -1,0 +1,27 @@
+package io.github.quiltservertools.blockbotapi.mixin;
+
+import io.github.quiltservertools.blockbotapi.event.PlayerLeaveMessageEvent;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ServerPlayNetworkHandler.class)
+public abstract class ServerPlayNetworkHandlerMixin {
+    @Shadow
+    public ServerPlayerEntity player;
+
+    @Inject(
+        method = "cleanUp",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/server/PlayerManager;broadcast(Lnet/minecraft/text/Text;Z)V"
+        )
+    )
+    private void relayLeaveMessageToDiscord(CallbackInfo ci) {
+        PlayerLeaveMessageEvent.EVENT.invoker().onPlayerLeaveMessage(this.player);
+    }
+}

--- a/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/mixin/TellRawCommandMixin.java
+++ b/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/mixin/TellRawCommandMixin.java
@@ -1,12 +1,11 @@
 package io.github.quiltservertools.blockbotapi.mixin;
 
 import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.context.ParsedCommandNode;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import io.github.quiltservertools.blockbotapi.event.ChatMessageEvent;
 import io.github.quiltservertools.blockbotapi.sender.MessageSender;
 import io.github.quiltservertools.blockbotapi.sender.PlayerMessageSender;
-import net.minecraft.command.EntitySelector;
-import net.minecraft.command.argument.EntityArgumentType;
 import net.minecraft.command.argument.TextArgumentType;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.command.TellRawCommand;
@@ -24,9 +23,12 @@ public abstract class TellRawCommandMixin {
         method = "method_13777",
         at = @At(value = "HEAD")
     )
-    private static void relayMeToDiscord(CommandContext<ServerCommandSource> context, CallbackInfoReturnable<Integer> cir) throws CommandSyntaxException {
-        // Check if tellraw is sent to every online player
-        if (context.getArgument("targets", EntitySelector.class).getLimit() > 1 && EntityArgumentType.getPlayers(context, "targets").size() == context.getSource().getPlayerNames().size()) {
+    private static void relayTellrawToDiscord(CommandContext<ServerCommandSource> context, CallbackInfoReturnable<Integer> cir) throws CommandSyntaxException {
+        // We are checking for "@a" to make sure only messages intended for the public are relayed.
+        // Messages with a selector like @a[distance=..100] should not be relayed.
+        String input = context.getInput();
+        ParsedCommandNode<ServerCommandSource> parsedCommandNode = context.getNodes().get(context.getNodes().size() - 2);
+        if (parsedCommandNode.getRange().get(input).equals("@a")) {
             var entity = context.getSource().getEntity();
             MessageSender sender;
             if (entity instanceof ServerPlayerEntity player) {

--- a/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/mixin/TellRawCommandMixin.java
+++ b/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/mixin/TellRawCommandMixin.java
@@ -5,12 +5,9 @@ import com.mojang.brigadier.context.ParsedCommandNode;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import io.github.quiltservertools.blockbotapi.event.ChatMessageEvent;
 import io.github.quiltservertools.blockbotapi.sender.MessageSender;
-import io.github.quiltservertools.blockbotapi.sender.PlayerMessageSender;
 import net.minecraft.command.argument.TextArgumentType;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.command.TellRawCommand;
-import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.text.Text;
 import net.minecraft.text.Texts;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -30,20 +27,7 @@ public abstract class TellRawCommandMixin {
         ParsedCommandNode<ServerCommandSource> parsedCommandNode = context.getNodes().get(context.getNodes().size() - 2);
         if (parsedCommandNode.getRange().get(input).equals("@a")) {
             var entity = context.getSource().getEntity();
-            MessageSender sender;
-            if (entity instanceof ServerPlayerEntity player) {
-                sender = new PlayerMessageSender(
-                    player,
-                    MessageSender.MessageType.REGULAR
-                );
-            } else {
-                sender = new MessageSender(
-                    Text.literal(context.getSource().getName()),
-                    context.getSource().getDisplayName(),
-                    MessageSender.MessageType.REGULAR
-                );
-            }
-
+            MessageSender sender = MessageSender.of(context.getSource(), MessageSender.MessageType.EMOTE);
             ChatMessageEvent.EVENT.invoker().message(
                 sender,
                 Texts.parse(context.getSource(), TextArgumentType.getTextArgument(context, "message"), entity, 0)

--- a/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/sender/MessageSender.java
+++ b/blockbot-api/src/main/java/io/github/quiltservertools/blockbotapi/sender/MessageSender.java
@@ -1,5 +1,7 @@
 package io.github.quiltservertools.blockbotapi.sender;
 
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,6 +14,24 @@ public class MessageSender {
         this.name = name;
         this.displayName = displayName;
         this.type = type;
+    }
+
+    public static MessageSender of(ServerCommandSource commandSource, MessageType type) {
+        var entity = commandSource.getEntity();
+        MessageSender sender;
+        if (entity instanceof ServerPlayerEntity player) {
+            sender = new PlayerMessageSender(
+                player,
+                type
+            );
+        } else {
+            sender = new MessageSender(
+                Text.literal(commandSource.getName()),
+                commandSource.getDisplayName(),
+                type
+            );
+        }
+        return sender;
     }
 
     public Text getName() {

--- a/blockbot-api/src/main/resources/blockbot-api.mixins.json
+++ b/blockbot-api/src/main/resources/blockbot-api.mixins.json
@@ -8,6 +8,7 @@
     "MixinPlayerAdvancementTracker",
     "MixinServerPlayerEntity",
     "PlayerManagerMixin",
+    "RandomCommandMixin",
     "SayCommandMixin",
     "ServerPlayNetworkHandlerMixin",
     "TellRawCommandMixin"

--- a/blockbot-api/src/main/resources/blockbot-api.mixins.json
+++ b/blockbot-api/src/main/resources/blockbot-api.mixins.json
@@ -7,7 +7,9 @@
     "MeCommandMixin",
     "MixinPlayerAdvancementTracker",
     "MixinServerPlayerEntity",
+    "PlayerManagerMixin",
     "SayCommandMixin",
+    "ServerPlayNetworkHandlerMixin",
     "TellRawCommandMixin"
   ],
   "server": [],

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     java
     id("maven-publish")
-    id("fabric-loom") version "1.2.+"
+    id("fabric-loom") version "1.5.+"
     kotlin("jvm") version "1.7.10"
     id("com.github.johnrengelman.shadow") version "7.1.2"
     kotlin("plugin.serialization") version "1.7.10"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,8 @@ allprojects {
         }
         maven("https://api.modrinth.com/maven")
         maven("https://oss.sonatype.org/content/repositories/snapshots")
+        // net.kyori:adventure-text-serializer-gson dev builds
+        maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
     }
 
     // Declare dependencies

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     java
     id("maven-publish")
-    id("fabric-loom") version "1.5.+"
+    id("fabric-loom") version "1.6.+"
     kotlin("jvm") version "1.7.10"
     id("com.github.johnrengelman.shadow") version "7.1.2"
     kotlin("plugin.serialization") version "1.7.10"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
 minecraft = "1.20.4"
-fabric-loader = "0.15.6"
-yarn-mappings = "1.20.4+build.1"
+fabric-loader = "0.15.10"
+yarn-mappings = "1.20.4+build.3"
 
-fabric-api = "0.91.2+1.20.4"
+fabric-api = "0.97.0+1.20.4"
 
 # Kotlin
 fabric-kotlin = "1.9.4+kotlin.1.8.21"
@@ -15,7 +15,7 @@ emoji-java = "5.1.1"
 adventure-gson = "4.15.0-SNAPSHOT"
 
 placeholder-api = "2.3.0+1.20.3"
-permission-api = "0.3-SNAPSHOT"
+permission-api = "0.3.1"
 vanish-api = "1.5.0+1.20.3-rc1"
 konf = "1.1.2"
 

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
-minecraft = "1.20.2"
-fabric-loader = "0.14.23"
-yarn-mappings = "1.20.2+build.1"
+minecraft = "1.20.4"
+fabric-loader = "0.15.1"
+yarn-mappings = "1.20.4+build.1"
 
-fabric-api = "0.90.0+1.20.2"
+fabric-api = "0.91.2+1.20.4"
 
 # Kotlin
 fabric-kotlin = "1.9.4+kotlin.1.8.21"
@@ -12,11 +12,11 @@ fabric-kotlin = "1.9.4+kotlin.1.8.21"
 kord-extensions = "1.5.6"
 mc-discord-reserializer = "4.3.0"
 emoji-java = "5.1.1"
-adventure-gson = "4.11.0"
+adventure-gson = "4.15.0-SNAPSHOT"
 
-placeholder-api = "2.2.0+1.20.2"
+placeholder-api = "2.3.0+1.20.3"
 permission-api = "0.3-SNAPSHOT"
-vanish-api = "1.4.3+1.20.2"
+vanish-api = "1.5.0+1.20.3-rc1"
 konf = "1.1.2"
 
 [libraries]

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 minecraft = "1.20.4"
-fabric-loader = "0.15.1"
+fabric-loader = "0.15.6"
 yarn-mappings = "1.20.4+build.1"
 
 fabric-api = "0.91.2+1.20.4"

--- a/src/main/kotlin/io/github/quiltservertools/blockbotdiscord/extensions/BlockBotApiExtension.kt
+++ b/src/main/kotlin/io/github/quiltservertools/blockbotdiscord/extensions/BlockBotApiExtension.kt
@@ -210,7 +210,7 @@ class BlockBotApiExtension : Extension(), Bot {
                             x += stepSize
                         }
 
-                        list.add(NbtString.of(Text.Serializer.toJson(text)))
+                        list.add(NbtString.of(Text.Serialization.toJsonString(text)))
                         y += stepSize
                         x = 0
                     }

--- a/src/main/kotlin/io/github/quiltservertools/blockbotdiscord/extensions/BlockBotApiExtension.kt
+++ b/src/main/kotlin/io/github/quiltservertools/blockbotdiscord/extensions/BlockBotApiExtension.kt
@@ -320,8 +320,8 @@ class BlockBotApiExtension : Extension(), Bot {
         }
     }
 
-    override fun onPlayerConnect(handler: ServerPlayNetworkHandler, sender: PacketSender, server: MinecraftServer) {
-        if (!handler.player.isVanished()) sendPlayerJoinMessage(handler.player)
+    override fun onPlayerJoinMessage(player: ServerPlayerEntity) {
+        if (player.isVanished()) sendPlayerJoinMessage(player)
     }
 
     private fun sendPlayerJoinMessage(player: ServerPlayerEntity) {
@@ -337,8 +337,8 @@ class BlockBotApiExtension : Extension(), Bot {
         }
     }
 
-    override fun onPlayerDisconnect(handler: ServerPlayNetworkHandler, server: MinecraftServer) {
-        if (!handler.player.isVanished()) sendPlayerLeaveMessage(handler.player)
+    override fun onPlayerLeaveMessage(player: ServerPlayerEntity) {
+        if (!player.isVanished()) sendPlayerLeaveMessage(player)
     }
 
     private fun sendPlayerLeaveMessage(player: ServerPlayerEntity) {

--- a/src/main/kotlin/io/github/quiltservertools/blockbotdiscord/extensions/BlockBotApiExtension.kt
+++ b/src/main/kotlin/io/github/quiltservertools/blockbotdiscord/extensions/BlockBotApiExtension.kt
@@ -321,7 +321,7 @@ class BlockBotApiExtension : Extension(), Bot {
     }
 
     override fun onPlayerJoinMessage(player: ServerPlayerEntity) {
-        if (player.isVanished()) sendPlayerJoinMessage(player)
+        if (!player.isVanished()) sendPlayerJoinMessage(player)
     }
 
     private fun sendPlayerJoinMessage(player: ServerPlayerEntity) {

--- a/src/main/kotlin/io/github/quiltservertools/blockbotdiscord/utility/Extensions.kt
+++ b/src/main/kotlin/io/github/quiltservertools/blockbotdiscord/utility/Extensions.kt
@@ -23,8 +23,8 @@ fun Message.summary(): String {
 
 fun GameProfile.getTextures() = Iterables.getFirst(this.properties.get("textures"), null)?.value
 
-fun Component.toNative(): MutableText = Text.Serializer.fromJson(GsonComponentSerializer.gson().serialize(this))?: Text.empty()
+fun Component.toNative(): MutableText = Text.Serialization.fromJson(GsonComponentSerializer.gson().serialize(this))?: Text.empty()
 
-fun Text.toAdventure() = GsonComponentSerializer.gson().deserialize(Text.Serializer.toJson(this))
+fun Text.toAdventure() = GsonComponentSerializer.gson().deserialize(Text.Serialization.toJsonString(this))
 
 fun ServerPlayerEntity.isVanished() = FabricLoader.getInstance().isModLoaded("melius-vanish") && VanishAPI.isVanished(this)


### PR DESCRIPTION
- Update to 1.20.4 (only text serialization related changes)
- Improved tellraw selector filter (will now only broadcast messages to discord that have exactly `@a` selector.
- Fix large images kicking players (The image interpolation only used width for determining the stepsize, this caused some  horizontal images to exceed the maximum nbt string length causing player disconnects!)